### PR TITLE
30動画を見て修正

### DIFF
--- a/src/main/java/raisetech/student/management/system/controller/StudentController.java
+++ b/src/main/java/raisetech/student/management/system/controller/StudentController.java
@@ -94,7 +94,7 @@ public class StudentController {
 
   @PostMapping("/updateStudent")
   public String updateStudent(@ModelAttribute StudentDetail studentDetail) {
-    service.updateStudents(studentDetail.getStudent(), studentDetail.getStudentCourses());
+    service.updateStudents(studentDetail);
     return "redirect:/studentList";
   }
 }

--- a/src/main/java/raisetech/student/management/system/repository/StudentRepository.java
+++ b/src/main/java/raisetech/student/management/system/repository/StudentRepository.java
@@ -1,6 +1,7 @@
 package raisetech.student.management.system.repository;
 
 import java.util.List;
+import org.apache.ibatis.annotations.Delete;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Options;
@@ -81,7 +82,7 @@ public interface StudentRepository {
    */
   @Update(
       "UPDATE students_courses SET course_id=#{courseId}, course_name=#{courseName}, date_start=#{dateStart},"
-          + "date_finish=#{dateFinish} WHERE student_id=#{studentId}")
+          + "date_finish=#{dateFinish} WHERE course_id=#{courseId}")
   void updateCourse(StudentCourse studentCourse);
 
-}
+  }

--- a/src/main/java/raisetech/student/management/system/service/StudentService.java
+++ b/src/main/java/raisetech/student/management/system/service/StudentService.java
@@ -50,7 +50,7 @@ public class StudentService {
 
   public StudentDetail getStudentById(int studentId) {
     Student student = repository.findStudentById(studentId);
-    List<StudentCourse> studentCourseList = repository.findCourseById(studentId);
+    List<StudentCourse> studentCourseList = repository.findCourseById(student.getStudentId());
     StudentDetail studentDetail = new StudentDetail();
     studentDetail.setStudent(student);
     studentDetail.setStudentCourses(studentCourseList);
@@ -60,15 +60,14 @@ public class StudentService {
   /**
    * 入力された受講生情報の更新
    *
-   * @param student
+   * @param studentDetail
    */
 
 
   @Transactional
-  public void updateStudents(Student student, List<StudentCourse> studentCourses) {
-    repository.updateStudent(student);
-    for (StudentCourse studentCourse : studentCourses) {
-      studentCourse.setStudentId(student.getStudentId());
+  public void updateStudents(StudentDetail studentDetail) {
+    repository.updateStudent(studentDetail.getStudent());
+    for (StudentCourse studentCourse : studentDetail.getStudentCourses()) {
       repository.updateCourse(studentCourse);
     }
   }

--- a/src/main/resources/templates/deletedStudentList.html
+++ b/src/main/resources/templates/deletedStudentList.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>$Title$</title>
+</head>
+<body>
+$END$
+</body>
+</html>

--- a/src/main/resources/templates/updateStudent.html
+++ b/src/main/resources/templates/updateStudent.html
@@ -47,33 +47,33 @@
     <label for="remark">備考欄:</label>
     <input type="text" id="remark" th:field="*{student.remark}" required/>
   </div>
-  <div class="course-cards">
-    <div class="card" th:each="course, iterStat : ${studentDetail.studentCourses}">
-      <div>
-        <label for="courseName">受講コース:</label>
-        <input type="text" id="courseName"
-               th:field="*{studentCourses[__${iterStat.index}__].courseName}" required/>
-      </div>
-      <div>
-        <label for="courseId">コースID:</label>
-        <input type="text" id="courseId"
-               th:field="*{studentCourses[__${iterStat.index}__].courseId}" required/>
-      </div>
-      <div>
-        <label for="dateStart">受講開始日:</label>
-        <input type="date" id="dateStart"
-               th:field="*{studentCourses[__${iterStat.index}__].dateStart}">
-      </div>
-      <div>
-        <label for="dateFinish">受講終了日:</label>
-        <input type="date" id="dateFinish"
-               th:field="*{studentCourses[__${iterStat.index}__].dateFinish}">
-      </div>
-    </div>
-    <div>
-      <button type="submit">更新</button>
-    </div>
+  <div th:each="course,stat : *{studentCourses}">
+    <label for="courseId"
+           th:for="studentCourse.__${stat.index}__.courseId">受講コースID：</label>
+    <input type="text" id="courseId" th:id="studentCourse.__${stat.index}__.courseId"
+           th:field="*{studentCourses[__${stat.index}__].courseId}"/>
+    <label for="courseName"
+           th:for="studentCourse.__${stat.index}__.courseName">受講コース名：</label>
+    <input type="text" id="courseName" th:id="studentCourse.__${stat.index}__.courseName"
+           th:field="*{studentCourses[__${stat.index}__].courseName}"/>
+    <label for="dateStart"
+           th:for="studentCourse.__${stat.index}__.dateStart">受講開始日：</label>
+    <input type="date" id="dateStart"
+           th:id="studentCourses.__${stat.index}__.dateStart"
+           th:field="*{studentCourses[__${stat.index}__].dateStart}"/>
+    <label for="dateFinish"
+           th:for="studentCourse.__${stat.index}__.dateFinish">受講開始日：</label>
+    <input type="date" id="dateFinish"
+           th:id="studentCourses.__${stat.index}__.dateFinish"
+           th:field="*{studentCourses[__${stat.index}__].dateFinish}"/>
   </div>
+  <div>
+    <button type="submit">更新</button>
+  </div>
+</form>
+<form th:action="@{/deleteStudent/{studentId}(studentId=${studentDetail.student.studentId})}"
+      method="post">
+  <button type="submit">削除</button>
 </form>
 </body>
 </html>


### PR DESCRIPTION
# 概要
画面操作で退会処理(論理削除)ができるよう実装いたしました。
また、削除されたデータは受講生一覧には表示されず、別のURLにて退会処理されたデータだけを表示させるようにしました。

## 更新前のデータ
<img width="1002" alt="スクリーンショット 2024-08-01 19 11 19" src="https://github.com/user-attachments/assets/c102bca3-5ae5-42f4-92f6-92719c10856c">

## 更新画面
11番のデータを選択し、退会のチェックボックスにチェックを入れ、更新ボタンを押す
<img width="928" alt="スクリーンショット 2024-08-01 19 14 24" src="https://github.com/user-attachments/assets/7cce38d2-e4ea-4f7e-b0d0-1c2d3f8a71af">

## 更新後のデータ
一覧からは削除される
<img width="981" alt="スクリーンショット 2024-08-01 19 15 09" src="https://github.com/user-attachments/assets/91eb41f0-5af1-49e4-8d92-d4414dc44661">

/deletedStudentListで削除されたデータの一覧を表示
<img width="833" alt="スクリーンショット 2024-08-01 19 16 08" src="https://github.com/user-attachments/assets/cefdd6b9-2519-441d-94cd-057a6ebf7fea">

[041440c](https://github.com/Mizuki0901/StudentManagementSystem/pull/12/commits/041440c9badc453df6f902d1890f269feada7854)ご確認よろしくお願いします。